### PR TITLE
Use metasearch instead of web

### DIFF
--- a/docker-compose-swarm.yml
+++ b/docker-compose-swarm.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 
 services:
-  web:
+  metasearch:
     image: "kasramp/metasearch:${IMAGE_TAG:-latest}"
     environment:
       SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}


### PR DESCRIPTION
To allow Kindler to reach to Metasearch via a meaningful service name. 
So instead of `http://web:8080`, it would be `http://metasearch:8080`